### PR TITLE
Improve I/O error diagnostics

### DIFF
--- a/examples/track_line.py
+++ b/examples/track_line.py
@@ -15,6 +15,8 @@ if __name__=='__main__':
     try:
         while True:
             Track_line()
+    except KeyboardInterrupt:
+        pass
     finally:
         fc.stop()
         print('Program stop')

--- a/picar_4wd/adc.py
+++ b/picar_4wd/adc.py
@@ -24,7 +24,8 @@ class ADC(I2C):
         try:
             self.send([self.chn, 0, 0], self.ADDR)
             self.recv(1, self.ADDR)
-        except OSError:
+        except OSError as e:
+            print(f"I/O error in ADC.__init__: {e}, switching to 0x15")
             self.ADDR = 0x15
         
     def read(self):                     

--- a/picar_4wd/i2c.py
+++ b/picar_4wd/i2c.py
@@ -12,13 +12,23 @@ class I2C(object):
         self._smbus = SMBus(self._bus)
 
     def auto_reset(func):
+        """Decorator to auto reset the I2C bus on I/O error.
+
+        When an :class:`OSError` is raised during I2C communication the
+        controller will be reset using :func:`soft_reset` and the operation
+        retried once.  The name of the function that failed is printed to aid
+        debugging so it is clear where the error occurred.
+        """
+
         def wrapper(*args, **kw):
             try:
                 return func(*args, **kw)
-            except OSError:
+            except OSError as e:
+                print(f"I/O error in {func.__name__}: {e}")
                 soft_reset()
                 time.sleep(1)
                 return func(*args, **kw)
+
         return wrapper
 
     @auto_reset

--- a/picar_4wd/motor.py
+++ b/picar_4wd/motor.py
@@ -24,10 +24,12 @@ class Motor():
             power = int(power /2 ) + 50
         power = power
 
-        direction = direction if not self._is_reversed else not direction  
-        self.dir_pin.value(direction)
-            
-        self.pwm_pin.pulse_width_percent(power)
+        direction = direction if not self._is_reversed else not direction
+        try:
+            self.dir_pin.value(direction)
+            self.pwm_pin.pulse_width_percent(power)
+        except OSError as e:
+            print(f"I/O error in Motor.set_power: {e}")
 
 #     def adder_thread(self):
 #         if self._except_power > self._power:

--- a/picar_4wd/pwm.py
+++ b/picar_4wd/pwm.py
@@ -21,7 +21,8 @@ class PWM(I2C):
             self.send(0x2C, self.ADDR)
             self.send(0, self.ADDR)
             self.send(0, self.ADDR)
-        except IOError:
+        except IOError as e:
+            print(f"I/O error in PWM.__init__: {e}, switching to 0x15")
             self.ADDR = 0x15
 
       #  self.debug = debug


### PR DESCRIPTION
## Summary
- add an informative message when the I2C auto reset is triggered
- log ADC and PWM initialization errors
- show motor driver I/O errors
- handle Ctrl+C in track_line example

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6851b338de6c832d9caeb1f083a5c4af