### PR TITLE
Add PiCamera streaming examples

### DIFF
--- a/examples/camera_web_stream.py
+++ b/examples/camera_web_stream.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+"""
+Simple camera stream using Flask and PiCamera.
+Install dependencies with:
+    pip3 install flask
+"""
+from flask import Flask, Response
+from picamera import PiCamera
+import io
+
+app = Flask(__name__)
+
+# Initialize camera with desired resolution
+camera = PiCamera()
+camera.resolution = (640, 480)
+
+
+def generate_frames():
+    """Video streaming generator function."""
+    stream = io.BytesIO()
+    for _ in camera.capture_continuous(stream, format='jpeg', use_video_port=True):
+        stream.seek(0)
+        frame = stream.read()
+        yield (b'--frame\r\n'
+               b'Content-Type: image/jpeg\r\n\r\n' + frame + b'\r\n')
+        stream.seek(0)
+        stream.truncate()
+
+
+@app.route('/camera')
+def camera_feed():
+    """Return the camera stream as an MJPEG feed."""
+    return Response(generate_frames(),
+                    mimetype='multipart/x-mixed-replace; boundary=frame')
+
+
+if __name__ == '__main__':
+    # Run the server on all interfaces so other machines can access it
+    app.run(host='0.0.0.0', port=8000, threaded=True)

--- a/examples/line_track_web_stream.py
+++ b/examples/line_track_web_stream.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""
+Line tracking with a live PiCamera stream.
+Requires flask:
+    pip3 install flask
+"""
+from threading import Thread
+import time
+import io
+from flask import Flask, Response
+from picamera import PiCamera
+import picar_4wd as fc
+
+app = Flask(__name__)
+
+# Setup camera resolution
+camera = PiCamera()
+camera.resolution = (640, 480)
+
+TRACK_LINE_SPEED = 20
+
+
+def generate_frames():
+    stream = io.BytesIO()
+    for _ in camera.capture_continuous(stream, format='jpeg', use_video_port=True):
+        stream.seek(0)
+        frame = stream.read()
+        yield (b'--frame\r\n'
+               b'Content-Type: image/jpeg\r\n\r\n' + frame + b'\r\n')
+        stream.seek(0)
+        stream.truncate()
+
+
+@app.route('/camera')
+def camera_feed():
+    return Response(generate_frames(), mimetype='multipart/x-mixed-replace; boundary=frame')
+
+
+def track_line_loop():
+    try:
+        while True:
+            gs_list = fc.get_grayscale_list()
+            status = fc.get_line_status(400, gs_list)
+            if status == 0:
+                fc.forward(TRACK_LINE_SPEED)
+            elif status == -1:
+                fc.turn_left(TRACK_LINE_SPEED)
+            elif status == 1:
+                fc.turn_right(TRACK_LINE_SPEED)
+            time.sleep(0.01)
+    finally:
+        fc.stop()
+
+
+if __name__ == '__main__':
+    t = Thread(target=track_line_loop)
+    t.daemon = True
+    t.start()
+    app.run(host='0.0.0.0', port=8000, threaded=True)


### PR DESCRIPTION
## Summary
- provide camera-only web streaming example
- add line tracking script with web streaming

## Testing
- `python3 -m py_compile examples/camera_web_stream.py examples/line_track_web_stream.py`

------
https://chatgpt.com/codex/tasks/task_e_685271b4d0ec832db4ca8c97f94719d5